### PR TITLE
Let Autofac resolve all parameters for LevelScene.ctor

### DIFF
--- a/CampingRace/CampingRaceGame/CampingRaceGame.projitems
+++ b/CampingRace/CampingRaceGame/CampingRaceGame.projitems
@@ -18,6 +18,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)GameComponents\SceneComponent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GameComponents\TreeComponent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IDrawable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ILevel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Level.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Scenes\IInitialScene.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Scenes\ILevelLoaderScene.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Scenes\ILevelScene.cs" />

--- a/CampingRace/CampingRaceGame/GameComponents/SceneComponent.cs
+++ b/CampingRace/CampingRaceGame/GameComponents/SceneComponent.cs
@@ -37,9 +37,9 @@ namespace CampingRaceGame.GameComponents
             this.currentScene.Draw(gameTime);
         }
 
-        public void ChangeScene<TScene>(params object[] args) where TScene : IScene
+        public void ChangeScene<TScene>() where TScene : IScene
         {
-            var scene = this.scenesFactory.Create<TScene>(args);
+            var scene = this.scenesFactory.Create<TScene>();
 
             if(this.currentScene != null)
             {

--- a/CampingRace/CampingRaceGame/ILevel.cs
+++ b/CampingRace/CampingRaceGame/ILevel.cs
@@ -1,0 +1,13 @@
+﻿using CampingRaceGame.Scenes.SceneObjects;
+
+namespace CampingRaceGame
+{
+    public interface ILevel
+    {
+        SceneObject[] SceneObjects
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CampingRace/CampingRaceGame/ILevel.cs
+++ b/CampingRace/CampingRaceGame/ILevel.cs
@@ -2,8 +2,14 @@
 
 namespace CampingRaceGame
 {
+    /// <summary>
+    /// Represents a level in the game.
+    /// </summary>
     public interface ILevel
     {
+        /// <summary>
+        /// Gets or sets the array of <see cref="SceneObject"/> in the current level.
+        /// </summary>
         SceneObject[] SceneObjects
         {
             get;

--- a/CampingRace/CampingRaceGame/Level.cs
+++ b/CampingRace/CampingRaceGame/Level.cs
@@ -2,8 +2,14 @@
 
 namespace CampingRaceGame
 {
+    /// <summary>
+    /// Represents a level in the game.
+    /// </summary>
     public class Level : ILevel
     {
+        /// <summary>
+        /// Gets or sets the array of <see cref="SceneObject"/> in the current level.
+        /// </summary>
         public SceneObject[] SceneObjects
         {
             get;

--- a/CampingRace/CampingRaceGame/Level.cs
+++ b/CampingRace/CampingRaceGame/Level.cs
@@ -1,0 +1,13 @@
+﻿using CampingRaceGame.Scenes.SceneObjects;
+
+namespace CampingRaceGame
+{
+    public class Level : ILevel
+    {
+        public SceneObject[] SceneObjects
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CampingRace/CampingRaceGame/Scenes/ILevelLoaderScene.cs
+++ b/CampingRace/CampingRaceGame/Scenes/ILevelLoaderScene.cs
@@ -1,6 +1,12 @@
-﻿namespace CampingRaceGame.Scenes
+﻿using CampingRaceGame.Scenes.SceneObjects;
+
+namespace CampingRaceGame.Scenes
 {
     public interface ILevelLoaderScene : IScene
     {
+        SceneObject[] SceneObjects
+        {
+            get;
+        }
     }
 }

--- a/CampingRace/CampingRaceGame/Scenes/ILevelLoaderScene.cs
+++ b/CampingRace/CampingRaceGame/Scenes/ILevelLoaderScene.cs
@@ -1,12 +1,6 @@
-﻿using CampingRaceGame.Scenes.SceneObjects;
-
-namespace CampingRaceGame.Scenes
+﻿namespace CampingRaceGame.Scenes
 {
     public interface ILevelLoaderScene : IScene
     {
-        SceneObject[] SceneObjects
-        {
-            get;
-        }
     }
 }

--- a/CampingRace/CampingRaceGame/Scenes/ISceneFactory.cs
+++ b/CampingRace/CampingRaceGame/Scenes/ISceneFactory.cs
@@ -2,6 +2,6 @@
 {
     public interface ISceneFactory
     {
-        TScene Create<TScene>(params object[] args) where TScene : IScene;
+        TScene Create<TScene>() where TScene : IScene;
     }
 }

--- a/CampingRace/CampingRaceGame/Scenes/ISceneManager.cs
+++ b/CampingRace/CampingRaceGame/Scenes/ISceneManager.cs
@@ -2,6 +2,6 @@
 {
     public interface ISceneManager
     {
-        void ChangeScene<TScene>(params object[] args) where TScene : IScene;
+        void ChangeScene<TScene>() where TScene : IScene;
     }
 }

--- a/CampingRace/CampingRaceGame/Scenes/LevelLoaderScene.cs
+++ b/CampingRace/CampingRaceGame/Scenes/LevelLoaderScene.cs
@@ -12,6 +12,12 @@ namespace CampingRaceGame.Scenes
         private SceneObject[] sceneObjects;
         private bool changedScene;
 
+        public SceneObject[] SceneObjects
+        {
+            get;
+            private set;
+        }
+
         public LevelLoaderScene(ISceneManager sceneManager, Game game, ISceneObjectFactory sceneObjectFactory)
         {
             if (sceneManager == null)
@@ -53,7 +59,8 @@ namespace CampingRaceGame.Scenes
             if(!this.changedScene)
             {
                 this.changedScene = true;
-                this.sceneManager.ChangeScene<ILevelScene>(this.sceneObjects);
+                this.SceneObjects = this.sceneObjects;
+                this.sceneManager.ChangeScene<ILevelScene>();
             }
         }
 

--- a/CampingRace/CampingRaceGame/Scenes/LevelLoaderScene.cs
+++ b/CampingRace/CampingRaceGame/Scenes/LevelLoaderScene.cs
@@ -9,16 +9,11 @@ namespace CampingRaceGame.Scenes
         private readonly ISceneManager sceneManager;
         private readonly Game game;
         private readonly ISceneObjectFactory sceneObjectFactory;
+        private readonly ILevel level;
         private SceneObject[] sceneObjects;
         private bool changedScene;
 
-        public SceneObject[] SceneObjects
-        {
-            get;
-            private set;
-        }
-
-        public LevelLoaderScene(ISceneManager sceneManager, Game game, ISceneObjectFactory sceneObjectFactory)
+        public LevelLoaderScene(ISceneManager sceneManager, Game game, ISceneObjectFactory sceneObjectFactory, ILevel level)
         {
             if (sceneManager == null)
             {
@@ -32,10 +27,15 @@ namespace CampingRaceGame.Scenes
             {
                 throw new ArgumentNullException(nameof(sceneObjectFactory));
             }
+            if(level == null)
+            {
+                throw new ArgumentNullException(nameof(level));
+            }
 
             this.sceneManager = sceneManager;
             this.game = game;
             this.sceneObjectFactory = sceneObjectFactory;
+            this.level = level;
         }
 
         public void Load()
@@ -59,7 +59,7 @@ namespace CampingRaceGame.Scenes
             if(!this.changedScene)
             {
                 this.changedScene = true;
-                this.SceneObjects = this.sceneObjects;
+                this.level.SceneObjects = this.sceneObjects;
                 this.sceneManager.ChangeScene<ILevelScene>();
             }
         }

--- a/CampingRace/CampingRaceGame/Scenes/LevelLoaderScene.cs
+++ b/CampingRace/CampingRaceGame/Scenes/LevelLoaderScene.cs
@@ -10,7 +10,6 @@ namespace CampingRaceGame.Scenes
         private readonly Game game;
         private readonly ISceneObjectFactory sceneObjectFactory;
         private readonly ILevel level;
-        private SceneObject[] sceneObjects;
         private bool changedScene;
 
         public LevelLoaderScene(ISceneManager sceneManager, Game game, ISceneObjectFactory sceneObjectFactory, ILevel level)
@@ -43,7 +42,7 @@ namespace CampingRaceGame.Scenes
             var tree = this.sceneObjectFactory.CreateTree();
             var player = this.sceneObjectFactory.CreatePlayer();
 
-            this.sceneObjects = new SceneObject[]
+            this.level.SceneObjects = new SceneObject[]
             {
                 tree,
                 player,
@@ -59,7 +58,6 @@ namespace CampingRaceGame.Scenes
             if(!this.changedScene)
             {
                 this.changedScene = true;
-                this.level.SceneObjects = this.sceneObjects;
                 this.sceneManager.ChangeScene<ILevelScene>();
             }
         }

--- a/CampingRace/CampingRaceGame/Scenes/LevelScene.cs
+++ b/CampingRace/CampingRaceGame/Scenes/LevelScene.cs
@@ -12,7 +12,7 @@ namespace CampingRaceGame.Scenes
         private SceneObject[] sceneObjects;
         private PlayersComponent playersComponent;
 
-        public LevelScene(ISceneManager sceneManager, Game game, SceneObject[] sceneObjects)
+        public LevelScene(ISceneManager sceneManager, Game game, ILevelLoaderScene levelLoaderScene)
         {
             if (sceneManager == null)
             {
@@ -22,10 +22,14 @@ namespace CampingRaceGame.Scenes
             {
                 throw new ArgumentNullException(nameof(game));
             }
+            if (levelLoaderScene == null)
+            {
+                throw new ArgumentNullException(nameof(levelLoaderScene));
+            }
 
             this.sceneManager = sceneManager;
             this.game = game;
-            this.sceneObjects = sceneObjects;
+            this.sceneObjects = levelLoaderScene.SceneObjects;
         }
 
         public void Load()

--- a/CampingRace/CampingRaceGame/Scenes/LevelScene.cs
+++ b/CampingRace/CampingRaceGame/Scenes/LevelScene.cs
@@ -1,5 +1,4 @@
 ﻿using CampingRaceGame.GameComponents;
-using CampingRaceGame.Scenes.SceneObjects;
 using Microsoft.Xna.Framework;
 using System;
 
@@ -9,10 +8,10 @@ namespace CampingRaceGame.Scenes
     {
         private readonly ISceneManager sceneManager;
         private readonly Game game;
-        private SceneObject[] sceneObjects;
+        private readonly ILevel level;
         private PlayersComponent playersComponent;
 
-        public LevelScene(ISceneManager sceneManager, Game game, ILevelLoaderScene levelLoaderScene)
+        public LevelScene(ISceneManager sceneManager, Game game, ILevel level)
         {
             if (sceneManager == null)
             {
@@ -22,14 +21,14 @@ namespace CampingRaceGame.Scenes
             {
                 throw new ArgumentNullException(nameof(game));
             }
-            if (levelLoaderScene == null)
+            if (level == null)
             {
-                throw new ArgumentNullException(nameof(levelLoaderScene));
+                throw new ArgumentNullException(nameof(level));
             }
 
             this.sceneManager = sceneManager;
             this.game = game;
-            this.sceneObjects = levelLoaderScene.SceneObjects;
+            this.level = level;
         }
 
         public void Load()
@@ -47,7 +46,7 @@ namespace CampingRaceGame.Scenes
         public void Draw(GameTime gameTime)
         {
             this.game.GraphicsDevice.Clear(Color.LemonChiffon);
-            foreach (var sceneObject in this.sceneObjects)
+            foreach (var sceneObject in this.level.SceneObjects)
             {
                 sceneObject.Draw();
             }

--- a/CampingRace/CampingRaceGame/Scenes/SceneFactory.cs
+++ b/CampingRace/CampingRaceGame/Scenes/SceneFactory.cs
@@ -1,6 +1,5 @@
 ﻿using Autofac;
 using System;
-using System.Linq;
 
 namespace CampingRaceGame.Scenes
 {
@@ -18,10 +17,9 @@ namespace CampingRaceGame.Scenes
             this.scope = scope;
         }
 
-        public TScene Create<TScene>(params object[] args) where TScene : IScene
+        public TScene Create<TScene>() where TScene : IScene
         {
-            var parameters = args.Select((o, i) => new PositionalParameter(i, o));
-            return this.scope.Resolve<TScene>(parameters);
+            return this.scope.Resolve<TScene>();
         }
     }
 }


### PR DESCRIPTION
This is one way to resolve issue #2. I'm not really satisfied with letting LevelScene require an instance of ILevelLoaderScene and thereby require ILevelLoaderScene to expose an array of SceneObject. Maybe some other Autofac known type can be shared between LevelScene and ILevelLoaderScene?